### PR TITLE
Enhance tunnel cleanup logic with subrequest limit protection

### DIFF
--- a/server/wrangler.jsonc
+++ b/server/wrangler.jsonc
@@ -8,7 +8,8 @@
     "enabled": true
   },
   "vars": {
-    "TUNNEL_MAX_AGE_HOURS": "4"
+    "TUNNEL_MAX_AGE_HOURS": "4",
+    "MAX_CLEANUPS_PER_RUN": "10"
   },
   "triggers": {
     "crons": ["*/30 * * * *"]


### PR DESCRIPTION
- Implemented `MAX_CLEANUPS_PER_RUN` environment variable to limit the number of tunnels cleaned per cron run, defaulting to 10 to comply with Cloudflare's subrequest limits.
- Updated the scheduled cleanup job to handle errors per tunnel, ensuring one failure does not halt the entire cleanup process.
- Enhanced CHANGELOG to document the new feature and improvements in error handling during cleanup.