### PR TITLE
feat(i18n): add Spanish language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Perfect for:
 - 📡 **WebSocket Support**: Full WebSocket and Server-Sent Events support
 - 🎯 **No Configuration**: Works out of the box
 - 💻 **Cross-Platform**: Windows, macOS, and Linux support
-- 🗣️ **Multilingual**: English and Vietnamese UI support
+- 🗣️ **Multilingual**: English, Vietnamese and Spanish UI support
 - 🆓 **100% Free**: No accounts, no limits, no paywalls
 - 🔓 **Open Source**: MIT licensed
 
@@ -172,7 +172,7 @@ nport <port> [options]
 | `--subdomain` | `-s` | Custom subdomain | `nport 3000 -s myapp` |
 | `--backend` | `-b` | Custom backend URL (temporary) | `nport 3000 -b https://your-backend.com` |
 | `--set-backend` | - | Save backend URL permanently | `nport --set-backend https://your-backend.com` |
-| `--language` | `-l` | Set language (en/vi) or prompt | `nport 3000 -l vi` |
+| `--language` | `-l` | Set language (en/vi/es) or prompt | `nport 3000 -l es` |
 | `--version` | `-v` | Show version information | `nport -v` |
 
 ### Language Options
@@ -183,6 +183,7 @@ NPort supports multiple languages with automatic detection on first run.
 # Set language directly
 nport 3000 --language en    # English
 nport 3000 -l vi            # Vietnamese
+nport 3000 -l es            # Español
 
 # Open language selection menu
 nport --language            # Interactive prompt
@@ -315,7 +316,7 @@ nport/
 | Time limits | ❌ None (4h auto-cleanup) | ⚠️ Free tier limited |
 | Open source | ✅ MIT | ❌ Proprietary |
 | Global network | ✅ Cloudflare | ✅ ngrok Edge |
-| Multilingual | ✅ EN/VI | ❌ English only |
+| Multilingual | ✅ EN/VI/ES | ❌ English only |
 
 ## 🧹 Cleanup
 
@@ -375,6 +376,7 @@ Then select your preferred language from the menu.
 
 - 🇺🇸 **English** (`en`) - Default
 - 🇻🇳 **Vietnamese** (`vi`) - Tiếng Việt
+- 🇪🇸 **Spanish** (`es`) - Español
 
 Want to add your language? Contributions are welcome! Check out the [Contributing Guide](docs/CONTRIBUTING.md).
 

--- a/src/bin-manager.ts
+++ b/src/bin-manager.ts
@@ -273,8 +273,12 @@ async function main(): Promise<void> {
   }
 }
 
-// Run if executed directly
-const currentFilePath = fileURLToPath(import.meta.url);
-if (process.argv[1] === currentFilePath || process.argv[1]?.endsWith('bin-manager.js')) {
+// Run only when this file is executed directly (not when bundled into index.js)
+const isDirectExecution =
+  process.argv[1] !== undefined &&
+  (process.argv[1].endsWith('bin-manager.js') ||
+   process.argv[1].endsWith('bin-manager.ts'));
+
+if (isDirectExecution) {
   main();
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -79,7 +79,7 @@ export const LOG_PATTERNS = {
 /**
  * Available language codes
  */
-export const AVAILABLE_LANGUAGES = ['en', 'vi'] as const;
+export const AVAILABLE_LANGUAGES = ['en', 'vi', 'es'] as const;
 
 /**
  * GitHub repository URL

--- a/src/lang.ts
+++ b/src/lang.ts
@@ -39,10 +39,11 @@ const TRANSLATIONS: Record<LanguageCode, TranslationKeys> = {
     versionAvailable: '🚨 New version available: v{version}',
     versionUpdate: 'Update now: ',
     learnMore: 'Learn more: ',
-    languagePrompt: '\n🌍 Language Selection / Chọn ngôn ngữ\n',
-    languageQuestion: 'Choose your language (1-2): ',
+    languagePrompt: '\n🌍 Language Selection / Chọn ngôn ngữ / Selección de idioma\n',
+    languageQuestion: 'Choose your language (1-3): ',
     languageEnglish: '1. English',
     languageVietnamese: '2. Tiếng Việt (Vietnamese)',
+    languageSpanish: '3. Español (Spanish)',
     languageInvalid: 'Invalid choice. Using English by default.',
     languageSaved: '✔ Language preference saved!',
     networkIssueTitle: '\n⚠️  NETWORK CONNECTIVITY ISSUE DETECTED',
@@ -94,9 +95,10 @@ const TRANSLATIONS: Record<LanguageCode, TranslationKeys> = {
     versionUpdate: 'Update khẩn trương lẹ làng: ',
     learnMore: 'Khám phá thêm cho nóng: ',
     languagePrompt: '\n🌍 Chọn lựa ngôn ngữ ngay bên dưới nào!\n',
-    languageQuestion: 'Chớp lấy một lựa chọn nha (1-2): ',
+    languageQuestion: 'Chớp lấy một lựa chọn nha (1-3): ',
     languageEnglish: '1. English (Chuẩn quốc tế!)',
     languageVietnamese: '2. Tiếng Việt (Đỉnh của chóp)',
+    languageSpanish: '3. Español (Tây Ban Nha)',
     languageInvalid: 'Ơ hơ, chọn sai rồi! Mặc định Tiếng Việt luôn cho nóng.',
     languageSaved: '🎯 Xong rồi! Lưu ngôn ngữ thành công!',
     networkIssueTitle: '\n⚠️  PHÁT HIỆN VẤN ĐỀ MẠNG',
@@ -113,6 +115,61 @@ const TRANSLATIONS: Record<LanguageCode, TranslationKeys> = {
     networkIssueFix4: '      • Tunnel sẽ tự động chuyển sang HTTP/2 nếu QUIC fail',
     networkIssueIgnore: '\n   ℹ️  Lỗi này thường không nghiêm trọng - tunnel vẫn hoạt động bình thường.\n',
     binaryChmodFailed: '⚠️  Không thể đặt quyền thực thi cho {filePath} (quyền bị từ chối).\n   Lỗi này thường xảy ra khi cài nport bằng sudo.\n   Binary vẫn hoạt động bình thường. Nếu gặp lỗi, thử một trong hai cách:\n      • Sửa quyền: sudo chmod 755 {filePath}\n      • Hoặc chạy nport với sudo: sudo nport [...args]',
+  },
+
+  es: {
+    header: 'N P O R T ⚡️ Gratis y código abierto desde Vietnam ❤️',
+    creatingTunnel: 'Creando túnel para el puerto {port}...',
+    checkingUpdates: 'Buscando actualizaciones...',
+    tunnelLive: '🚀 ¡ESTAMOS EN VIVO!',
+    connection1: '   ✔ [1/2] Conexión establecida...',
+    connection2: '   ✔ [2/2] Compresión activada...',
+    timeRemaining: '⏱️  Tiempo:     {hours}h restantes',
+    footerTitle: '🔥 ¿MANTENER LA VIBRA VIVA?',
+    footerSubtitle: '(Hecho con ❤️ en Vietnam)',
+    dropStar: '⭐️  Déjanos una Estrella:   ',
+    sendCoffee: '☕️  Invítanos un Café:    ',
+    newVersion: '🚨 ¡NUEVA VERSIÓN (v{version}) detectada!',
+    updateCommand: '> npm install -g nport@latest',
+    tunnelShutdown: '🛑 TÚNEL APAGADO.',
+    cleaningUp: 'Limpiando...',
+    cleanupDone: 'Listo.',
+    cleanupFailed: 'Falló.',
+    subdomainReleased: 'Subdominio...   Liberado. 🗑️',
+    serverBusy: '(El servidor podría estar caído o ocupado)',
+    goodbyeTitle: '👋 ANTES DE IRTE...',
+    goodbyeMessage: '¡Gracias por usar NPort!',
+    website: '🌐 Sitio web:     ',
+    author: '👤 Autor:      ',
+    changeLanguage: '🌍 Idioma:    ',
+    changeLanguageHint: 'nport --language',
+    versionTitle: 'NPort v{version}',
+    versionSubtitle: 'Alternativa gratuita y de código abierto a ngrok',
+    versionLatest: '✔ ¡Estás usando la última versión!',
+    versionAvailable: '🚨 Nueva versión disponible: v{version}',
+    versionUpdate: 'Actualiza ahora: ',
+    learnMore: 'Más información: ',
+    languagePrompt: '\n🌍 Selección de idioma / Language Selection / Chọn ngôn ngữ\n',
+    languageQuestion: 'Elige tu idioma (1-3): ',
+    languageEnglish: '1. English (Inglés)',
+    languageVietnamese: '2. Tiếng Việt (Vietnamita)',
+    languageSpanish: '3. Español',
+    languageInvalid: 'Opción inválida. Usando inglés por defecto.',
+    languageSaved: '✔ ¡Preferencia de idioma guardada!',
+    networkIssueTitle: '\n⚠️  PROBLEMA DE CONECTIVIDAD DE RED DETECTADO',
+    networkIssueDesc: '   Cloudflared está teniendo problemas para mantener una conexión estable con los servidores edge de Cloudflare.',
+    networkIssueTunnel: '   📡 Tu túnel sigue funcionando, pero la calidad de la conexión puede verse afectada.',
+    networkIssueReasons: '\n   💡 Posibles razones:',
+    networkIssueReason1: '      • Conexión a internet inestable o alta pérdida de paquetes',
+    networkIssueReason2: '      • Firewall/Router bloqueando tráfico UDP (protocolo QUIC)',
+    networkIssueReason3: '      • Limitación del ISP o congestión de red',
+    networkIssueFix: '\n   🔧 Qué puedes intentar:',
+    networkIssueFix1: '      • Verifica la estabilidad de tu conexión a internet',
+    networkIssueFix2: '      • Prueba conectarte desde otra red',
+    networkIssueFix3: '      • Desactiva la VPN/Proxy si estás usando una',
+    networkIssueFix4: '      • El túnel cambiará automáticamente a HTTP/2 si QUIC falla',
+    networkIssueIgnore: '\n   ℹ️  Esto generalmente no es crítico: tu túnel debería seguir funcionando con normalidad.\n',
+    binaryChmodFailed: '⚠️  No se pudieron establecer permisos de ejecución en {filePath} (permiso denegado).\n   Esto suele ocurrir cuando nport se instaló con sudo.\n   El binario debería seguir funcionando. Si tienes problemas, prueba una de estas opciones:\n      • Corregir permisos: sudo chmod 755 {filePath}\n      • O ejecutar nport con sudo: sudo nport [...args]',
   }
 };
 
@@ -188,7 +245,8 @@ class LanguageManager {
 
       console.log(this.t('languagePrompt'));
       console.log(`   ${this.t('languageEnglish')}`);
-      console.log(`   ${this.t('languageVietnamese')}\n`);
+      console.log(`   ${this.t('languageVietnamese')}`);
+      console.log(`   ${this.t('languageSpanish')}\n`);
 
       rl.question(`${this.t('languageQuestion')}`, (answer) => {
         rl.close();
@@ -200,6 +258,8 @@ class LanguageManager {
           selectedLang = 'en';
         } else if (choice === '2') {
           selectedLang = 'vi';
+        } else if (choice === '3') {
+          selectedLang = 'es';
         } else {
           console.log(`\n${this.t('languageInvalid')}\n`);
         }

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -61,6 +61,7 @@ export interface TranslationKeys {
   languageQuestion: string;
   languageEnglish: string;
   languageVietnamese: string;
+  languageSpanish: string;
   languageInvalid: string;
   languageSaved: string;
   

--- a/src/types/i18n.ts
+++ b/src/types/i18n.ts
@@ -5,7 +5,7 @@
 /**
  * Supported language codes
  */
-export type LanguageCode = 'en' | 'vi';
+export type LanguageCode = 'en' | 'vi' | 'es';
 
 /**
  * Translation keys used in the application


### PR DESCRIPTION
## Summary
Adds Spanish (`es`) language support for the CLI and fixes a side effect in `bin-manager` when bundled.

Closes #26

### Details
- Full Spanish translations
- Language selection prompt updated (option 3: Español)
- Fix: `bin-manager`'s `main()` no longer runs when bundled into `dist/index.js` (was interleaving cloudflared messages with the language prompt)

## Changes
- `src/lang.ts` — Spanish translation strings + prompt updates
- `src/constants.ts` / `src/types/i18n.ts` — register `es` language
- `src/bin-manager.ts` — only run `main()` when executed directly (`bin-manager.js` / `.ts`)

## Test plan
- [x] `npm run build`
- [x] `node dist/index.js -l` → shows 3 languages, no cloudflared noise
- [x] Select Spanish → preference saved, subsequent runs use Spanish UI
- [x] `node dist/index.js 9000` → Spanish messages display correctly